### PR TITLE
Change to activate virtualenv in getting_started

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -63,7 +63,8 @@ If you don't use conda (see above), create a virtual environment::
     Depending on your platform, the Python 3 interpreter could be invoked by
     ``python`` instead. This is the case for conda on Windows for example.
 
-Install ``aiohttp`` in the virtual environment::
+Activate the virtual environment and install ``aiohttp`` inside:
 
-    ./venv/bin/python -m pip install -U aiohttp
+    source ./venv/bin/activate
+    pip install -U aiohttp
 

--- a/getting_started.rst
+++ b/getting_started.rst
@@ -65,6 +65,6 @@ If you don't use conda (see above), create a virtual environment::
 
 Activate the virtual environment and install ``aiohttp`` inside:
 
-    source ./venv/bin/activate
+    source venv/bin/activate
     pip install -U aiohttp
 


### PR DESCRIPTION
While it is not the topic of this doc to explain how to use a virtualenv, I fear that beginners will have issues when trying the examples as the virtual environment will not be loaded and they will think to use `./venv/bin/python` for launching every example.
