### PR TITLE
Improve consume/produce examples

### DIFF
--- a/examples/producer_consumer.py
+++ b/examples/producer_consumer.py
@@ -32,6 +32,7 @@ async def consume(queue):
 
 loop = asyncio.get_event_loop()
 queue = asyncio.Queue(loop=loop)
-asyncio.ensure_future(produce(queue, 10), loop=loop)
-loop.run_until_complete(consume(queue))
+producer_coro = produce(queue, 10)
+consumer_coro = consume(queue)
+loop.run_until_complete(asyncio.gather(producer_coro, consumer_coro))
 loop.close()

--- a/examples/producer_consumer_join.py
+++ b/examples/producer_consumer_join.py
@@ -29,9 +29,13 @@ async def consume(queue):
 
 async def run(n):
     queue = asyncio.Queue()
+    # register the consume coroutine
     consumer = asyncio.ensure_future(consume(queue))
+    # launch the producer and wait for completion
     await produce(queue, n)
+    # ensure the consumer consumes all produced items
     await queue.join()
+    # consumer is always awaiting for a new item, cancel it
     consumer.cancel()
 
 


### PR DESCRIPTION
Use asyncio.gather instead of asyncio.ensure_future in the first example (more understandable). Add  comments to the second example. 
