### PR TITLE
Fix the star count.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -146,7 +146,7 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None)}
 # documentation.
 #
 html_theme_options = {
-    'github_user': 'asyncio-doc',
+    'github_user': 'asyncio-docs',
     'github_repo': 'asyncio-doc',
     'github_banner': True,
     'github_type': 'star',


### PR DESCRIPTION
Currently at http://asyncio.readthedocs.io/en/latest/, it is not showing the numbers of stars correctly.

With this change, the docs will show how many people starred this project.
Screenshot:

<img width="271" alt="screen shot 2017-11-08 at 8 03 02 pm" src="https://user-images.githubusercontent.com/5844587/32587892-f040b376-c4bf-11e7-8f46-d88d99e752ad.png">
