### PR TITLE
Fix docstring in hello_clock.py example

### DIFF
--- a/examples/hello_clock.py
+++ b/examples/hello_clock.py
@@ -2,7 +2,7 @@ import asyncio
 
 
 async def print_every_second():
-    "Print seconds"
+    """Print seconds"""
     while True:
         for i in range(60):
             print(i, 's')


### PR DESCRIPTION
It was just a double quoted string.
It should be triple quoted.