### PR TITLE
Fix example http_client

### DIFF
--- a/examples/http_client.py
+++ b/examples/http_client.py
@@ -1,15 +1,15 @@
 import asyncio
 import aiohttp
 
-async def fetch_page(session, url):
-    with aiohttp.Timeout(10):
+async def fetch_page(url):
+    timeout = aiohttp.ClientTimeout(10)
+    async with aiohttp.ClientSession(loop=loop, timeout=timeout) as session:
         async with session.get(url) as response:
             assert response.status == 200
             return await response.read()
 
 loop = asyncio.get_event_loop()
-with aiohttp.ClientSession(loop=loop) as session:
-    content = loop.run_until_complete(
-        fetch_page(session, 'http://python.org'))
-    print(content)
+content = loop.run_until_complete(
+    fetch_page('http://python.org'))
+print(content)
 loop.close()


### PR DESCRIPTION
The example stopped working due to changes in `aiohttp`:
- ClientSession manager is now async
- `aiohttp.Timeout` does not exist anymore

Fixes  #36